### PR TITLE
Add dashboard view for video and signal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@
           ]" />
         <div class="flex-grow overflow-y-auto space-y-6 h-full pb-4 max-[800px]:pb-16 max-[800px]:mx-2" style="min-height: 0;">
           <!-- Primary View -->
+          <DashboardView v-if="primaryView === 'dashboard'" class="view" />
           <VisualizationView v-if="primaryView === 'visualization'" class="view"/>
           <SignalConfigView v-if="primaryView === 'signal'" class="view" :selected-data-source="selectedDataSource" :serial-settings="serialSettings" :tcp-settings="tcpSettings" :fake-data-settings="fakeDataSettings" @data-source-changed="onDataSourceChanged" />
           <FilterConfigView v-if="primaryView === 'filters'" class="view" />
@@ -68,8 +69,9 @@ import SignalConfigView from './components/views/SignalConfigView.vue';
 import FilterConfigView from './components/views/FilterConfigView.vue';
 import RecordingView from './components/views/RecordingView.vue';
 import StreamingView from './components/views/StreamingView.vue';
+import DashboardView from './components/views/DashboardView.vue';
 import AppHeader from './components/AppHeader.vue';
-const primaryView = ref('visualization'); // Options: 'visualization', 'signal', 'filters', 'folder', 'streaming', 'videorecord'
+const primaryView = ref('dashboard'); // Options: 'dashboard', 'visualization', 'signal', 'filters', 'folder', 'streaming'
 const additionalViews = ref<string[]>([]);
 const collapsed = ref(false);
 

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -10,6 +10,20 @@
 
     <div
       class="space-y-3 max-[800px]:space-y-0 max-[800px]:flex max-[800px]:flex-row max-[800px]:space-x-3 max-[800px]:justify-center">
+      <div @click="setActiveView('dashboard')" :class="[`p-4 rounded-lg cursor-pointer transition-all duration-300 transform hover:translate-x-1`,
+        activeView === 'dashboard'
+          ? 'bg-blue-600 bg-opacity-20 border-l-4 border-blue-500 rounded-r-lg'
+          : 'bg-gray-700 hover:bg-gray-600']">
+        <div class="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+            <line x1="3" y1="9" x2="21" y2="9"></line>
+            <line x1="9" y1="21" x2="9" y2="9"></line>
+          </svg>
+          <h3 v-if="!collapsed" class="font-bold max-[800px]:hidden">{{ $t('sidebar.dashboard') }}</h3>
+        </div>
+      </div>
       <div @click="setActiveView('visualization')" :class="[`p-4 rounded-lg cursor-pointer transition-all duration-300 transform hover:translate-x-1`,
         activeView === 'visualization'
           ? 'bg-blue-600 bg-opacity-20 border-l-4 border-blue-500 rounded-r-lg'

--- a/src/components/views/DashboardView.vue
+++ b/src/components/views/DashboardView.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="bg-gray-800 bg-opacity-60 rounded-lg p-6 space-y-6">
+    <div class="flex flex-wrap gap-6">
+      <StreamingView class="flex-1 min-w-[320px]" />
+      <SignalConfigView
+        class="flex-1 min-w-[320px]"
+        :selected-data-source="selectedDataSource"
+        :serial-settings="serialSettings"
+        :tcp-settings="tcpSettings"
+        :fake-data-settings="fakeDataSettings"
+        @data-source-changed="onDataSourceChanged"
+      />
+    </div>
+    <div class="flex gap-4">
+      <button @click="connectAll" class="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-md text-white">
+        Connect Both
+      </button>
+      <button
+        @click="toggleRecording"
+        :class="isRecording ? 'bg-red-600 hover:bg-red-700' : 'bg-green-600 hover:bg-green-700'"
+        class="px-4 py-2 rounded-md text-white"
+      >
+        {{ isRecording ? 'Stop Recording' : 'Record Both' }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { invoke } from '@tauri-apps/api/core';
+import { mkdir, BaseDirectory } from '@tauri-apps/plugin-fs';
+import * as path from '@tauri-apps/api/path';
+import StreamingView from './StreamingView.vue';
+import SignalConfigView from './SignalConfigView.vue';
+import { serialSettings, tcpSettings, fakeDataSettings } from '../../store/appState';
+
+const selectedDataSource = ref('fake');
+function onDataSourceChanged(source: 'serial' | 'tcp' | 'fake') {
+  selectedDataSource.value = source;
+}
+
+const streamUrl = ref('http://192.168.1.123:81/stream');
+const isRecording = ref(false);
+
+async function connectAll() {
+  try {
+    await invoke('start_streaming', { path: streamUrl.value, fake: false });
+
+    if (selectedDataSource.value === 'serial') {
+      await invoke('connect_serial', {
+        port: serialSettings.port,
+        baudRate: serialSettings.baudRate,
+        stopBits: serialSettings.stopBits,
+        parity: serialSettings.parity,
+        dataBits: serialSettings.dataBits
+      });
+    } else if (selectedDataSource.value === 'tcp') {
+      await invoke('connect_socket', { host: tcpSettings.host, port: tcpSettings.port });
+    } else {
+      await invoke('start_fake_data', {
+        config: {
+          min_value: fakeDataSettings.minValue,
+          max_value: fakeDataSettings.maxValue,
+          frequency: fakeDataSettings.frequency,
+          channel_count: fakeDataSettings.channelCount,
+          waveform: fakeDataSettings.waveform
+        }
+      });
+    }
+  } catch (err) {
+    console.error('Error connecting:', err);
+  }
+}
+
+async function toggleRecording() {
+  if (isRecording.value) {
+    await invoke('stop_stream_recording');
+    await invoke('stop_recording');
+    isRecording.value = false;
+  } else {
+    try {
+      const documentDir = await path.documentDir();
+      try { await mkdir('video_data', { baseDir: BaseDirectory.Document }); } catch (_) {}
+      const videoDir = await path.join(documentDir, 'video_data');
+      const ts = new Date().toISOString().replace(/[:.]/g, '-');
+      const videoFile = await path.join(videoDir, `video_${ts}.mp4`);
+      await invoke('start_stream_recording', { filePath: videoFile });
+
+      try { await mkdir('signal_data', { baseDir: BaseDirectory.Document }); } catch (_) {}
+      const signalDir = await path.join(documentDir, 'signal_data');
+      await invoke('start_recording', { format: 'csv', directory: signalDir, maxDurationMinutes: 30, autoStart: false });
+      isRecording.value = true;
+    } catch (err) {
+      console.error('Error starting recording:', err);
+    }
+  }
+}
+</script>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -10,6 +10,7 @@
     "language": "Language"
   },
   "sidebar": {
+    "dashboard": "Dashboard",
     "visualization": "Visualization",
     "signal": "Signal Settings",
     "filters": "Filters",

--- a/src/i18n/zh.json
+++ b/src/i18n/zh.json
@@ -10,6 +10,7 @@
     "language": "语言"
   },
   "sidebar": {
+    "dashboard": "总览",
     "visualization": "数据可视化",
     "signal": "信号设置",
     "filters": "滤波器",


### PR DESCRIPTION
## Summary
- create `DashboardView` to show streaming and signal config together
- display the new dashboard as the default main page
- add dashboard item to sidebar and translations

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c5f6c1788324846958b57d01cde7